### PR TITLE
Adding persistent storage, metrics and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,86 +10,34 @@ Do not forget to update rhn-username, pools, etc ...
 To have OpenShift Enterprise 3.4 running on Azure, you will have to
 follow 2 steps.
 - First deploy the cluster with one of the following method.
-- Then use ansible to install OSE 3.4 ( in a word run the
-openshift-install.sh script.
+- Then use Ansible to install OpenShift Container Platform 3.4
 
-### Create the cluster on the Azure Portal
+### Step 1 - Create the cluster
+
+#### From the Azure Portal
+
+Click on Deploy to Azure then you will be redirected to your Azure account
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Flbroudoux%2Fopenshift-azure%2Frhel%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FWilliamRedHat%2Fopenshift-azure%2Frhel%2Fazuredeploy.json" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Flbroudoux%2Fopenshift-azure%2Frhel%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-### Create the cluster with powershell
+Wait for the installation to be ready this will consist of having one infra node, one master and a number of nodes. Then go to the group that contains those machines and get the "OPENSHIFT MASTER SSH" command line that you will need for the next step.
+
+#### From powershell CLI
 
 ```powershell
-New-AzureRmResourceGroupDeployment -Name <DeploymentName> -ResourceGroupName <RessourceGroupName> -TemplateUri https://raw.githubusercontent.com/WilliamRedHat/openshift-azure/rhel/azuredeploy.json
-```
-### Create the cluster with Azure CLI on RHEL 7.3
-
-#### Install Azure CLI
-Use the knowledge base article : https://access.redhat.com/articles/1994463
-
-#### Use the Azure CLI
+New-AzureRmResourceGroupDeployment -Name <DeploymentName> -ResourceGroupName <RessourceGroupName> -TemplateUri https://raw.githubusercontent.com/lbroudoux/openshift-azure/rhel/azuredeploy.json
 ```
 
-[hoffmann@william ~]$ git clone https://github.com/WilliamRedHat/openshift-azure.git
-[hoffmann@william ~]$ cd ~/openshift-azure/
-```
+#### Common parameters
 
-Update the azuredeploy.parameters.json file with your parameters
+Both methods implies the following parameters :
 
-Create a resource group :
-
-```
-  [hoffmann@william ~]$ azure config mode arm
-  [hoffmann@william ~]$ azure location list
-  [hoffmann@william ~]$ azure group create -n "RG-OSE34" -l "West US"
-  [hoffmann@william ~]$ azure group deployment create -f azuredeploy.json -e azuredeploy.parameters.json RG-OSE34 dnsName
-
-```
-Note the output :
-
-```
-  data:    Outputs            :
-  data:    Name                        Type    Value                                       
-  data:    --------------------------  ------  --------------------------------------------
-  data:    openshift Webconsole        String  https://ose34.westus.cloudapp.azure.com:8443
-  data:    openshift Master ssh        String  ssh -A 13.91.51.205                         
-  data:    openshift Router Public IP  String  13.91.101.166                               
-  info:    group deployment create command OK
-
-```
-You're now able to go to the next step.
-
-## Install Openshift with Ansible
-
-You must use SSH Agentforwarding.
-You must register your systems into RHN and to add the proper channels.
-
-```
-[adminUsername@master ~]$ ./openshift-install.sh
-```
-
-## Configure NFS storage
-FIXME : add pv / pvc
-```
-[adminUsername@infranode ~]$ sudo su -
-[adminUsername@infranode ~]$ yum install nfs-utils  rpcbind
-[adminUsername@infranode ~]$ systemctl enable nfs-server
-[adminUsername@infranode ~]$ systemctl enable rpcbind
-[adminUsername@infranode ~]$ mkdir /exports
-[adminUsername@infranode ~]$ vim /etc/exports
-[adminUsername@infranode ~]$ systemctl start nfs-server
-[adminUsername@infranode ~]$ exportfs -r
-```
-
-------
-
-## Parameters
-### Input Parameters
+##### Input Parameters
 
 ```
 | Name          | Type          | Description                                      |   |
@@ -100,12 +48,12 @@ FIXME : add pv / pvc
 | masterDnsName | String        | DNS Prefix for the Openshift Master / Webconsole |   |
 | numberOfNodes | Integer       | Number of Openshift Nodes to create              |   |
 | image         | String        | Operating System to use. RHEL or CentOs          |   |
-| rhnUser      | String        | Red Hat Network user id                          |   |
-| rhnPass      | SecureString  | Red Hat Network password                         |   |
-| rhnPool      | String        | Red Hat Network pool id                          |   |
+| rhnUser       | String        | Red Hat Network user id                          |   |
+| rhnPass       | SecureString  | Red Hat Network password                         |   |
+| rhnPool       | String        | Red Hat Network pool id                          |   |
 
 ```
-### Output Parameters
+##### Output Parameters
 
 ```
 | Name| Type           | Description |
@@ -115,4 +63,47 @@ FIXME : add pv / pvc
 | openshift Router Public IP | String       | Router Public IP. Needed if you want to create your own Wildcard DNS |
 
 ```
-------
+
+You're now able to go to the next step.
+
+### Step 2 - Install Openshift with Ansible
+
+You must connect to OpenShift master using SSH with Agent forwarding. So from your local machine:
+
+```
+[username@localmachine ~]$ ssh-add
+```
+so that the SSH forwarding Agent will forward the necessary data to the script that will then install OpenShift.
+
+Then connect using your user name and the IP of master node. Example
+
+```
+[username@localmachine ~]$ ssh -A laurent@13.236.112.237
+```
+
+Then on the master you'll need to run this script :
+
+```
+[adminUsername@master ~]$ ./openshift-install.sh
+```
+The cluster is installed in 15 minutes or so. It creates 2 users (admin and demo with password redhat123). The admin user is set up as cluster admin. At the end of the script, you may be automatically logged in using admin user.
+
+## Adding NFS storage
+
+Setup scripts install a NFS server on `infranode` during the construction of Azure topology. For applications that need Persistent Volumes you will need to  run this extra script :
+
+```
+[adminUsername@master ~]$ ./create-pvs.sh
+```
+
+This is adding a bunch of Persistent volumes of different capacities for your applications.
+
+## Adding Metrics and logging
+
+If you need to demo the metrics or logging features of OpenShift, it is just easy to add them after the storage by running this extra script created during installation :
+
+```
+[adminUsername@master ~]$ ./openshift-services-deploy.sh
+```
+
+Metrics and logging features are respectively deployed into `openshift-infra` and `logging` projects after few minutes.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This work is based on https://github.com/derdanu
+This work is based on https://github.com/WilliamRedHat
 
 # RedHat Openshift 3.4 cluster on Azure
 
@@ -15,7 +15,7 @@ openshift-install.sh script.
 
 ### Create the cluster on the Azure Portal
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FWilliamRedHat%2Fopenshift-azure%2Frhel%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Flbroudoux%2Fopenshift-azure%2Frhel%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FWilliamRedHat%2Fopenshift-azure%2Frhel%2Fazuredeploy.json" target="_blank">

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -94,7 +94,7 @@
     "infranodeSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('infranodesubnetName'))]",
     "nodeSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('nodesubnetName'))]",
     "masterSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('mastersubnetName'))]",
-    "infranodeVMSize": "Standard_D2_v2",
+    "infranodeVMSize": "Standard_D3_v2",
     "nodeVMSize": "Standard_D2_v2",
     "masterVMSize": "Standard_D3_v2",
     "centos": {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -90,6 +90,7 @@
     "nodeStorageName": "[concat(uniqueString(resourceGroup().id), 'nodesa')]",
     "masterStorageName": "[concat(uniqueString(resourceGroup().id), 'mastersa')]",
     "vhdStorageType": "Standard_LRS",
+    "infraVhdStorageType": "Premium_LRS",
     "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
     "infranodeSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('infranodesubnetName'))]",
     "nodeSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('nodesubnetName'))]",
@@ -120,7 +121,7 @@
         "displayName": "StorageAccount"
       },
       "properties": {
-        "accountType": "[variables('vhdStorageType')]"
+        "accountType": "[variables('infraVhdStorageType')]"
       }
     },
     {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -72,7 +72,7 @@
       }
   },
   "variables": {
-  "baseTemplateUrl": "https://raw.githubusercontent.com/WilliamRedHat/openshift-azure/rhel/",
+  "baseTemplateUrl": "https://raw.githubusercontent.com/lbroudoux/openshift-azure/rhel/",
     "baseVMachineTemplateUriInfranode": "[concat(variables('baseTemplateUrl'), 'infranode.json')]",
     "baseVMachineTemplateUriNode": "[concat(variables('baseTemplateUrl'), 'node.json')]",
     "baseVMachineTemplateUriMaster": "[concat(variables('baseTemplateUrl'), 'master.json')]",
@@ -369,4 +369,3 @@
     }
   }
 }
-

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -95,7 +95,7 @@
     "infranodeSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('infranodesubnetName'))]",
     "nodeSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('nodesubnetName'))]",
     "masterSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('mastersubnetName'))]",
-    "infranodeVMSize": "Standard_D3_v2",
+    "infranodeVMSize": "Standard_DS3_v2",
     "nodeVMSize": "Standard_D2_v2",
     "masterVMSize": "Standard_D3_v2",
     "centos": {

--- a/infranode.json
+++ b/infranode.json
@@ -166,8 +166,8 @@
         "type": "CustomScriptForLinux",
         "typeHandlerVersion": "1.3",
         "settings": {
-          "fileUris": [ "[concat(parameters('baseTemplateUrl'), 'node.sh')]", "[concat(parameters('baseTemplateUrl'), 'infranode.sh')]" ],
-          "commandToExecute": "[concat('sh node.sh ', parameters('rhnUser'), ' ', parameters('rhnPass'), ' ', parameters('rhnPool'), ' && sh infranode.sh')]"
+          "fileUris": [ "[concat(parameters('baseTemplateUrl'), 'node.sh')]" ],
+          "commandToExecute": "[concat('sh node.sh ', parameters('rhnUser'), ' ', parameters('rhnPass'), ' ', parameters('rhnPool'))]"
         }
       }
     },

--- a/infranode.json
+++ b/infranode.json
@@ -166,8 +166,8 @@
         "type": "CustomScriptForLinux",
         "typeHandlerVersion": "1.3",
         "settings": {
-          "fileUris": [ "[concat(parameters('baseTemplateUrl'), 'node.sh')]" ],
-          "commandToExecute": "[concat('sh node.sh ', parameters('rhnUser'), ' ', parameters('rhnPass'), ' ', parameters('rhnPool'))]"
+          "fileUris": [ "[concat(parameters('baseTemplateUrl'), 'node.sh')]", "[concat(parameters('baseTemplateUrl'), 'infranode.sh')]" ],
+          "commandToExecute": "[concat('sh node.sh ', parameters('rhnUser'), ' ', parameters('rhnPass'), ' ', parameters('rhnPool'), ' && sh infranode.sh')]"
         }
       }
     },

--- a/infranode.json
+++ b/infranode.json
@@ -166,8 +166,8 @@
         "type": "CustomScriptForLinux",
         "typeHandlerVersion": "1.3",
         "settings": {
-          "fileUris": [ "[concat(parameters('baseTemplateUrl'), 'node.sh')]", "[concat(parameters('baseTemplateUrl'), 'infranode.sh')]" ],
-          "commandToExecute": "[concat('sh node.sh ', parameters('rhnUser'), ' ', parameters('rhnPass'), ' ', parameters('rhnPool'), ' && sh infranode.sh')]"
+          "fileUris": [ "[concat(parameters('baseTemplateUrl'), 'infranode.sh')]" ],
+          "commandToExecute": "[concat('sh infranode.sh ', parameters('rhnUser'), ' ', parameters('rhnPass'), ' ', parameters('rhnPool'))]"
         }
       }
     },

--- a/infranode.sh
+++ b/infranode.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Install a NFS server on infranode
-sudo su -
 yum install nfs-utils rpcbind
 systemctl enable nfs-server
 systemctl enable rpcbind

--- a/infranode.sh
+++ b/infranode.sh
@@ -30,7 +30,7 @@ systemctl enable docker
 
 
 # Install a NFS server on infranode
-yum install nfs-utils rpcbind
+yum -y install nfs-utils rpcbind
 systemctl enable nfs-server
 systemctl enable rpcbind
 systemctl start rpcbind
@@ -63,7 +63,7 @@ while [ $n -le 20 ]
   (( n++ ))
 done
 
-CAT <<EOF > /etc/exports.d/openshif-ansible
+cat <<EOF > /etc/exports.d/openshif-ansible.exports
 /exports/registry *(rw,root_squash)
 /exports/metrics *(rw,root_squash)
 /exports/logging-es *(rw,root_squash)

--- a/infranode.sh
+++ b/infranode.sh
@@ -47,6 +47,13 @@ cd /exports
 mkdir registry
 mkdir metrics
 mkdir logging-es
+chown -R nfsnobody:nfsnobody registry/
+chown -R nfsnobody:nfsnobody metrics/
+chown -R nfsnobody:nfsnobody logging-es/
+chmod -R 777 registry/
+chmod -R 777 metrics/
+chmod -R 777 logging-es/
+
 n=1
 while [ $n -le 9 ]
   do mkdir pv000$n

--- a/infranode.sh
+++ b/infranode.sh
@@ -2,7 +2,7 @@
 
 # Install a NFS server on infranode
 sudo su -
-yum install nfs-utils  rpcbind
+yum install nfs-utils rpcbind
 systemctl enable nfs-server
 systemctl enable rpcbind
 systemctl start nfs-server

--- a/infranode.sh
+++ b/infranode.sh
@@ -1,16 +1,52 @@
 #!/bin/bash
+# Last Modified : 2016-05-26
+
+rhn_username=$1
+rhn_pass=$2
+rhn_pool=$3
+
+
+subscription-manager register --username=${rhn_username} --password=${rhn_pass} --force
+subscription-manager attach --pool=${rhn_pool}
+
+subscription-manager repos --disable="*"
+subscription-manager repos --enable="rhel-7-server-rpms" --enable="rhel-7-server-rpms" --enable="rhel-7-server-extras-rpms" --enable="rhel-7-server-ose-3.4-rpms"
+
+sed -i -e 's/sslverify=1/sslverify=0/' /etc/yum.repos.d/rh-cloud.repo
+sed -i -e 's/sslverify=1/sslverify=0/' /etc/yum.repos.d/rhui-load-balancers
+
+yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion docker
+yum -y update
+
+sed -i -e "s#^OPTIONS='--selinux-enabled'#OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0/16'#" /etc/sysconfig/docker
+
+cat <<EOF > /etc/sysconfig/docker-storage-setup
+DEVS=/dev/sdc
+VG=docker-vg
+EOF
+
+docker-storage-setup
+systemctl enable docker
+
 
 # Install a NFS server on infranode
 yum install nfs-utils rpcbind
 systemctl enable nfs-server
 systemctl enable rpcbind
 systemctl start nfs-server
+systemctl start rpcbind
+
+systemctl stop firewalld
+systemctl disable firewalld
 
 # Create exports directory for hosting Persistent Volumes
 mkdir /exports
 cd /exports
 
 # Create a bunch of directories for later PV
+mkdir registry
+mkdir metrics
+mkdir logging-es
 n=1
 while [ $n -le 9 ]
   do mkdir pv000$n
@@ -28,6 +64,9 @@ while [ $n -le 20 ]
 done
 
 CAT <<EOF > /etc/exports.d/openshif-ansible
+/exports/registry *(rw,root_squash)
+/exports/metrics *(rw,root_squash)
+/exports/logging-es *(rw,root_squash)
 /exports/pv0001 *(rw,root_squash)
 /exports/pv0002 *(rw,root_squash)
 /exports/pv0003 *(rw,root_squash)

--- a/infranode.sh
+++ b/infranode.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Install a NFS server on infranode
+sudo su -
+yum install nfs-utils  rpcbind
+systemctl enable nfs-server
+systemctl enable rpcbind
+systemctl start nfs-server
+
+# Create exports directory for hosting Persistent Volumes
+mkdir /exports
+cd /exports
+
+# Create a bunch of directories for later PV
+n=1
+while [ $n -le 9 ]
+  do mkdir pv000$n
+  chown -R nfsnobody:nfsnobody pv000$n/
+  chmod -R 777 pv000$n
+  (( n++ ))
+done
+
+n=10
+while [ $n -le 20 ]
+  do mkdir pv00$n
+  chown -R nfsnobody:nfsnobody pv00$n/
+  chmod -R 777 pv00$n
+  (( n++ ))
+done
+
+CAT <<EOF > /etc/exports.d/openshif-ansible
+/exports/pv0001 *(rw,root_squash)
+/exports/pv0002 *(rw,root_squash)
+/exports/pv0003 *(rw,root_squash)
+/exports/pv0004 *(rw,root_squash)
+/exports/pv0005 *(rw,root_squash)
+/exports/pv0006 *(rw,root_squash)
+/exports/pv0007 *(rw,root_squash)
+/exports/pv0008 *(rw,root_squash)
+/exports/pv0009 *(rw,root_squash)
+/exports/pv0010 *(rw,root_squash)
+/exports/pv0011 *(rw,root_squash)
+/exports/pv0012 *(rw,root_squash)
+/exports/pv0013 *(rw,root_squash)
+/exports/pv0014 *(rw,root_squash)
+/exports/pv0015 *(rw,root_squash)
+/exports/pv0016 *(rw,root_squash)
+/exports/pv0017 *(rw,root_squash)
+/exports/pv0018 *(rw,root_squash)
+/exports/pv0019 *(rw,root_squash)
+/exports/pv0020 *(rw,root_squash)
+EOF
+
+# Exports everything and force refresh of iptables
+exportfs -r
+iptables -F

--- a/infranode.sh
+++ b/infranode.sh
@@ -33,8 +33,8 @@ systemctl enable docker
 yum install nfs-utils rpcbind
 systemctl enable nfs-server
 systemctl enable rpcbind
-systemctl start nfs-server
 systemctl start rpcbind
+systemctl start nfs-server
 
 systemctl stop firewalld
 systemctl disable firewalld

--- a/master.sh
+++ b/master.sh
@@ -40,6 +40,7 @@ cat <<EOF > /etc/ansible/hosts
 [OSEv3:children]
 masters
 nodes
+nfs
 
 [OSEv3:vars]
 ansible_ssh_user=${USERNAME}
@@ -52,10 +53,6 @@ openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 
 openshift_master_default_subdomain=${ROUTEREXTIP}.xip.io
 openshift_use_dnsmasq=False
 
-openshift_registry_selector="role=infra"
-openshift_router_selector="role=infra"
-
-
 # Install the openshift examples
 openshift_install_examples=true
 
@@ -63,10 +60,10 @@ openshift_install_examples=true
 use_cluster_metrics=true
 
 # Configure metricsPublicURL in the master config for cluster metrics
-openshift_master_metrics_public_url=https://${HOSTNAME}/hawkular/metrics
+openshift_master_metrics_public_url=https://metrics.${ROUTEREXTIP}.xip.io/hawkular/metrics
 
 # Configure loggingPublicURL in the master config for aggregate logging
-openshift_master_logging_public_url=https://kibana.${HOSTNAME}
+openshift_master_logging_public_url=https://kibana.${ROUTEREXTIP}.xip.io
 
 # Defining htpasswd users (password is redhat123)
 openshift_master_htpasswd_users={'admin': '\$apr1\$bdqbl2eo\$Na6mZ6SG7Vfo3YPyp1vJP.', 'demo': '\$apr1\$ouJ9QtwY\$Z2WZ9yvm1.tNzipdR.4Wp1'}
@@ -75,20 +72,36 @@ openshift_master_htpasswd_users={'admin': '\$apr1\$bdqbl2eo\$Na6mZ6SG7Vfo3YPyp1v
 osm_use_cockpit=true
 osm_cockpit_plugins=['cockpit-kubernetes']
 
+# default project node selector
+osm_default_node_selector='region=primary'
+
 openshift_router_selector='region=infra'
 openshift_registry_selector='region=infra'
 
+# Configure an internal regitry
+openshift_hosted_registry_selector=‘region=infra'
+openshift_hosted_registry_replicas=1
+openshift_hosted_registry_storage_kind=nfs
+openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
+openshift_hosted_registry_storage_host=infranoce
+openshift_hosted_registry_storage_nfs_directory=/exports
+openshift_hosted_registry_storage_volume_name=registry
+openshift_hosted_registry_storage_volume_size=5Gi
 
-# Configure an internal regitry / NOT YET SUPPORTED
-# openshift_hosted_registry_storage_kind=nfs
-# openshift_hosted_registry_storage_host=infranode
-# openshift_hosted_registry_storage_nfs_directory=/exports
-# openshift_hosted_registry_storage_volume_name=registry
-# openshift_hosted_registry_storage_volume_size=5Gi
+# Enable metrics
+openshift_hosted_metrics_deploy=true
+openshift_hosted_metrics_storage_kind=nfs
+openshift_hosted_metrics_storage_access_modes=['ReadWriteOnce']
+openshift_hosted_metrics_storage_host=oselab.example.com
+openshift_hosted_metrics_storage_nfs_directory=/exports
+openshift_hosted_metrics_storage_volume_name=metrics
+openshift_hosted_metrics_storage_volume_size=5Gi
+
+[nfs]
+infranode
 
 [masters]
 master openshift_node_labels="{'region': 'infra', 'zone': 'default'}"  openshift_public_hostname=${HOSTNAME}
-
 
 [nodes]
 master
@@ -103,3 +116,142 @@ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
 EOF
 
 chmod 755 /home/${USERNAME}/openshift-install.sh
+
+n=1
+while [ $n -le 9 ]
+do
+cat <<EOF > /home/${USERNAME}/pv000$n.json
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolume",
+  "metadata": {
+    "name": "pv000$n"
+  },
+  "spec": {
+    "capacity": {
+        "storage": "1Gi"
+    },
+    "accessModes": [ "ReadWriteOnce", "ReadWriteMany" ],
+    "nfs": {
+        "path": "/exports/pv000$n",
+        "server": "infranode"
+    },
+    "persistentVolumeReclaimPolicy": "Recycle"
+  }
+}
+EOF
+(( n++ ))
+done
+
+n=10
+while [ $n -le 15 ]
+do
+cat <<EOF > /home/${USERNAME}/pv00$n.json
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolume",
+  "metadata": {
+    "name": "pv00$n"
+  },
+  "spec": {
+    "capacity": {
+        "storage": "5Gi"
+    },
+    "accessModes": [ "ReadWriteOnce", "ReadWriteMany" ],
+    "nfs": {
+        "path": "/exports/pv00$n",
+        "server": "infranode"
+    },
+    "persistentVolumeReclaimPolicy": "Recycle"
+  }
+}
+EOF
+(( n++ ))
+done
+
+n=16
+while [ $n -le 20 ]
+do
+cat <<EOF > /home/${USERNAME}/pv00$n.json
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolume",
+  "metadata": {
+    "name": "pv00$n"
+  },
+  "spec": {
+    "capacity": {
+        "storage": "25Gi"
+    },
+    "accessModes": [ "ReadWriteOnce", "ReadWriteMany" ],
+    "nfs": {
+        "path": "/exports/pv00$n",
+        "server": "infranode"
+    },
+    "persistentVolumeReclaimPolicy": "Recycle"
+  }
+}
+EOF
+(( n++ ))
+done
+
+cat <<EOF > /home/${USERNAME}/create-pvs.sh
+n=1
+while [ \$n -le 9 ]
+do
+  oc create -f pv000\$n.json
+  (( n++ ))
+done
+n=10
+while [ \$n -le 20 ]
+do
+oc create -f pv00\$n.json
+(( n++ ))
+done
+EOF
+
+chmod 755 /home/${USERNAME}/create-pvs.sh
+
+cat <<EOF > /home/${USERNAME}/openshift-services-deploy.sh
+
+oc project openshift-infra
+oc annotate namespace openshift-infra openshift.io/node-selector='region=infra' --overwrite
+oadm policy add-role-to-user edit system:serviceaccount:openshift-infra:metrics-deployer
+oadm policy add-cluster-role-to-user cluster-reader system:serviceaccount:openshift-infra:heapster
+oc adm policy add-role-to-user view system:serviceaccount:openshift-infra:hawkular -n openshift-infra
+
+oc process metrics-deployer-template -n openshift \
+  -v HAWKULAR_METRICS_HOSTNAME=metrics.${ROUTEREXTIP}.xip.io \
+  -v IMAGE_VERSION=v3.4 -v IMAGE_PREFIX=registry.access.redhat.com/openshift3/ \
+  -v USE_PERSISTENT_STORAGE=true \
+  -v CASSANDRA_PV_SIZE=5Gi \
+  | oc create -f -
+
+oc project logging
+oc new-app logging-deployer-account-template
+oadm policy add-cluster-role-to-user oauth-editor system:serviceaccount:logging:logging-deployer
+oadm policy add-scc-to-user privileged system:serviceaccount:logging:aggregated-logging-fluentd
+oadm policy add-cluster-role-to-user cluster-reader system:serviceaccount:logging:aggregated-logging-fluentd
+oadm policy add-cluster-role-to-user rolebinding-reader system:serviceaccount:logging:aggregated-logging-elasticsearch
+
+oc process logging-deployer-template -n openshift \
+  -v KIBANA_HOSTNAME=kibana.${ROUTEREXTIP}.xip.io \
+  -v ES_CLUSTER_SIZE=1 \
+  -v ES_INSTANCE_RAM=2G \
+  -v ES_PVC_SIZE=5G \
+  -v ES_NODESELECTOR='region=infra' \
+  -v KIBANA_NODESELECTOR='region=infra' \
+  -v CURATOR_NODESELECTOR='region=infra' \
+  -v PUBLIC_MASTER_URL=https://${HOSTNAME}:8443 \
+  -v ENABLE_OPS_CLUSTER=false \
+  -v IMAGE_VERSION=v3.4 \
+  -v IMAGE_PREFIX=registry.access.redhat.com/openshift3/ \
+  | oc create -f -
+
+n=1
+while [ \$n -le $NODECOUNT ]
+do
+  oc label node/node0$n logging-infra-fluentd=true
+  (( n++ ))
+done
+EOF

--- a/master.sh
+++ b/master.sh
@@ -35,6 +35,11 @@ docker-storage-setup
 systemctl enable docker
 systemctl start docker
 
+yum -y install nfs-utils rpcbind
+systemctl enable rpcbind
+systemctl start rpcbind
+setsebool -P virt_sandbox_use_nfs 1
+setsebool -P virt_use_nfs 1
 
 cat <<EOF > /etc/ansible/hosts
 [OSEv3:children]

--- a/master.sh
+++ b/master.sh
@@ -314,12 +314,7 @@ oc process logging-deployer-template -n openshift \
   -v IMAGE_PREFIX=registry.access.redhat.com/openshift3/ \
   | oc create -f -
 
-n=1
-while [ \$n -le $NODECOUNT ]
-do
-  oc label node/node0\$n logging-infra-fluentd=true
-  (( n++ ))
-done
+oc label --selector='region=primary' logging-infra-fluentd=true
 EOF
 
 chmod 755 /home/${USERNAME}/openshift-services-deploy.sh

--- a/master.sh
+++ b/master.sh
@@ -88,7 +88,7 @@ openshift_hosted_registry_storage_volume_name=registry
 openshift_hosted_registry_storage_volume_size=15Gi
 
 # Enable metrics
-openshift_hosted_metrics_deploy=true
+openshift_hosted_metrics_deploy=false
 openshift_hosted_metrics_storage_kind=nfs
 openshift_hosted_metrics_storage_access_modes=['ReadWriteOnce']
 openshift_hosted_metrics_storage_host=infranode
@@ -97,7 +97,7 @@ openshift_hosted_metrics_storage_volume_name=metrics
 openshift_hosted_metrics_storage_volume_size=5Gi
 
 # Enable logging
-openshift_hosted_logging_deploy=true
+openshift_hosted_logging_deploy=false
 openshift_hosted_logging_prefix=registry.access.redhat.com/openshift3/
 openshift_hosted_logging_version=v3.4
 openshift_hosted_logging_deployer_prefix=registry.access.redhat.com/openshift3/
@@ -124,14 +124,15 @@ master openshift_node_labels="{'region': 'infra', 'zone': 'default'}"  openshift
 
 [nodes]
 master
-node[01:${NODECOUNT}] openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
 infranode openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+node[01:${NODECOUNT}] openshift_node_labels="{'region': 'primary', 'zone': 'default'}"
 
 EOF
 
 cat <<EOF > /home/${USERNAME}/openshift-install.sh
 export ANSIBLE_HOST_KEY_CHECKING=False
 ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
+oc annotate namespace default openshift.io/node-selector='region=infra' --overwrite
 oadm policy add-cluster-role-to-user admin admin
 EOF
 

--- a/node.sh
+++ b/node.sh
@@ -27,3 +27,12 @@ EOF
 
 docker-storage-setup
 systemctl enable docker
+
+yum -y install nfs-utils rpcbind
+systemctl start rpcbind
+systemctl enable rpcbind
+setsebool -P virt_sandbox_use_nfs 1
+setsebool -P virt_use_nfs 1
+
+systemctl stop firewalld
+systemctl disable firewalld

--- a/node.sh
+++ b/node.sh
@@ -29,8 +29,8 @@ docker-storage-setup
 systemctl enable docker
 
 yum -y install nfs-utils rpcbind
-systemctl start rpcbind
 systemctl enable rpcbind
+systemctl start rpcbind
 setsebool -P virt_sandbox_use_nfs 1
 setsebool -P virt_use_nfs 1
 


### PR DESCRIPTION
Hi William,

here's a PR for enhancements and fixes on original work.

## Fixes
- Force number of router to 1 because only one infra node schedulable,
- Add persistent volume to deployed registry
- Install NFS and enforce usage of NFS from nodes

## Enhancement
- Change to premium storage for infra node
- Add NFS Server on infra node and prepare a bunch of exports
- Add scripts for creating Persistent Volumes in OCP after cluster install
- Add scripts for adding Metrics and Logging in OCP after storage setup

Regards,